### PR TITLE
Hide private cycles

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -143,6 +143,8 @@ GEM
     nio4r (2.5.8)
     nokogiri (1.13.3-arm64-darwin)
       racc (~> 1.4)
+    nokogiri (1.13.3-x86_64-darwin)
+      racc (~> 1.4)
     public_suffix (4.0.6)
     puma (5.6.4)
       nio4r (~> 2.0)
@@ -242,6 +244,7 @@ GEM
 
 PLATFORMS
   arm64-darwin-21
+  x86_64-darwin-20
 
 DEPENDENCIES
   bootsnap
@@ -270,4 +273,4 @@ RUBY VERSION
    ruby 3.0.3p157
 
 BUNDLED WITH
-   2.3.5
+   2.3.9

--- a/app/controllers/cycles_controller.rb
+++ b/app/controllers/cycles_controller.rb
@@ -1,5 +1,5 @@
 class CyclesController < ApplicationController
   def index
-    @cycles = Cycle.all
+    @cycles = Cycle.where(public_status: true)
   end
 end


### PR DESCRIPTION
This PR fixes issue #1.

In the `CyclesController` class and its `index` method, I replaced the call to retrieve all cycles, `Cycle.all`, with a call to retrieve only the cycles whose `public_status` is `true`, `Cycle.where(public_status: true)`.

These changes make sure only the **public** cycles are displayed and the **private** cycles remain hidden.

When I cloned the repo and ran `bundle`, the `Gemfile.lock` file was modified, too.